### PR TITLE
fix(adr-check): validate the real corpus at docs/src/adr

### DIFF
--- a/justfile
+++ b/justfile
@@ -114,7 +114,7 @@ adr-check:
     set -euo pipefail
     adroit="$(just _adroit-resolve)"
     if [ -n "$adroit" ] && [ -x "$adroit" ]; then
-        "$adroit" check --dir docs/adr
+        "$adroit" check --dir docs/src/adr
     else
         echo "skip: no adroit binary (set ADROIT_BIN, build ../adroit, install adroit on PATH, or set COMO_GIT_BASE for the .como/tools install)"
     fi


### PR DESCRIPTION
Part of como-technologies/portfolio#1. `just adr-check` pointed at the gone `docs/adr`; `adroit check` creates a missing dir empty and passes, so the gate validated nothing. Now checks the real 11 accepted ADRs.